### PR TITLE
Checkout builder in CI to work with older upstream

### DIFF
--- a/.github/workflows/poolside-nightly-build.yaml
+++ b/.github/workflows/poolside-nightly-build.yaml
@@ -24,6 +24,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PYTORCH_FINAL_PACKAGE_DIR: /artifacts
   PYTORCH_ROOT: /pytorch
+  BUILDER_ROOT: /builder
   SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
   SKIP_ALL_TESTS: 1
   # All vars below are from the auto-generated ./generated-linux-binary-manywheel-nightly.yml
@@ -75,6 +76,7 @@ jobs:
         run: |
           {
             echo "PYTORCH_ROOT=${{ env.PYTORCH_ROOT }}"
+            echo "BUILDER_ROOT=${{ env.BUILDER_ROOT }}"
             echo "PACKAGE_TYPE=${{ env.PACKAGE_TYPE }}"
             echo "DESIRED_CUDA=${{ env.DESIRED_CUDA }}"
             echo "GPU_ARCH_VERSION=${{ env.GPU_ARCH_VERSION }}"
@@ -110,6 +112,22 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
+
+    - name: Checkout pytorch/builder to builder dir
+        uses: malfet/checkout@silent-checkout
+        with: 
+          ref: main
+          submodules: recursive
+          repository: pytorch/builder
+          path: builder
+          quiet-checkout: true
+
+      - name: Clean pytorch/builder checkout
+        run: |
+          # Remove any artifacts from the previous checkouts
+          git clean -fxd
+        working-directory: builder
+
       - name: Build PyTorch binary
         run: |
           set -x
@@ -128,6 +146,7 @@ jobs:
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
             -e PYTORCH_ROOT \
+            -e BUILDER_ROOT \
             -e SKIP_ALL_TESTS \
             -e PYTORCH_EXTRA_INSTALL_REQUIREMENTS \
             -e USE_SPLIT_BUILD \
@@ -136,6 +155,7 @@ jobs:
             --tty \
             --detach \
             -v "${GITHUB_WORKSPACE}/pytorch:/pytorch" \
+            -v "${GITHUB_WORKSPACE}/builder:/builder" \
             -v "${RUNNER_TEMP}/artifacts:/artifacts" \
             -w / \
             "${DOCKER_IMAGE}"


### PR DESCRIPTION
As we reverted to an earlier version of torch, we need to checkout pytorch/builder for the build to work.