### PR TITLE
socket: set ipv6 preference to false

### DIFF
--- a/torch/csrc/distributed/c10d/socket.h
+++ b/torch/csrc/distributed/c10d/socket.h
@@ -52,7 +52,8 @@ class SocketOptions {
   }
 
  private:
-  bool prefer_ipv6_ = true;
+  // XXX: keeping this here for now, addressing separately upstream
+  bool prefer_ipv6_ = false;
   std::chrono::milliseconds connect_timeout_{std::chrono::seconds{30}};
   std::shared_ptr<Backoff> connect_backoff_{
       std::make_shared<FixedBackoff>(std::chrono::milliseconds(1000))};


### PR DESCRIPTION
Torch relies on explicitly setting the address family to AF_INET6 by default when using `getaddrinfo`. This results in ENONAME on systems which do not have IPv6 available, as is the case within EKS in our setup.

The correct behavior should be to set the family to AF_UNSPEC, and if necessary to rely on `gai.conf` to set precedence to control which address is returned first. This will be addressed separately by raising a PR upstream.

In the interval, our fork should default to IPv4 to allow host lookups to work as intended.

Fixes #ISSUE_NUMBER
